### PR TITLE
arch=compute_30 is not supported in Cuda 11.2, should be removed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,6 @@ if (WITH_OMP)
 endif()
 
 # need to be at least 30 or __shfl_down in reduce wont compile
-set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_30,code=sm_30 -O2")
-set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_35,code=sm_35")
-
 set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_50,code=sm_50")
 set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_52,code=sm_52")
 IF(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5)


### PR DESCRIPTION
If we would like to compile with CUDA 11.2, we must remove the old compute_30, computer_35 arch models.
Cuda was removing the support for it, therefore does not compile if we still keep there.

<!-- gk-ai-analysis-start:e0deb921c75fc71707e3bbd826476cb2ab042225 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiUmVtb3ZlZCBkZXByZWNhdGVkIGBjb21wdXRlXzMwYCBhbmQgYGNvbXB1dGVfMzVgIENVREEgYXJjaGl0ZWN0dXJlcyB0byBlbmFibGUgY29tcGlsYXRpb24gd2l0aCBDVURBIDExLjIuIiwia2V5SW5zaWdodHMiOlt7InRpdGxlIjoiUmVtb3ZlZCBsZWdhY3kgQ1VEQSBhcmNoaXRlY3R1cmVzIiwiZGVzY3JpcHRpb24iOiJSZW1vdmVkIGAtZ2VuY29kZSBhcmNoPWNvbXB1dGVfMzAsY29kZT1zbV8zMGAgYW5kIGAtZ2VuY29kZSBhcmNoPWNvbXB1dGVfMzUsY29kZT1zbV8zNWAgZnJvbSBgQ1VEQV9OVkNDX0ZMQUdTYCBhcyB0aGV5IGFyZSBubyBsb25nZXIgc3VwcG9ydGVkIGluIENVREEgMTEuMi4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoiQ01ha2VMaXN0cy50eHQiLCJsaW5lU3RhcnQiOjQ3fV0sImlzc3VlcyI6W10sInN1Z2dlc3Rpb25zIjpbeyJ0aXRsZSI6Ik1pc3Npbmcgb3B0aW1pemF0aW9uIGZsYWciLCJkZXNjcmlwdGlvbiI6IlRoZSBgLU8yYCBvcHRpbWl6YXRpb24gZmxhZyB3YXMgcmVtb3ZlZCBhbG9uZyB3aXRoIHRoZSBgY29tcHV0ZV8zMGAgYXJjaGl0ZWN0dXJlIGxpbmUuIFZlcmlmeSBpZiB0aGlzIGZsYWcgbmVlZHMgdG8gYmUgcHJlc2VydmVkIGFuZCBhcHBlbmRlZCB0byBgQ1VEQV9OVkNDX0ZMQUdTYCBzZXBhcmF0ZWx5LiIsInNldmVyaXR5IjoibG93IiwiZmlsZVBhdGgiOiJDTWFrZUxpc3RzLnR4dCIsImxpbmVTdGFydCI6NDh9XSwic2VjdXJpdHkiOltdfQ== -->
<!-- gk-ai-analysis-end:e0deb921c75fc71707e3bbd826476cb2ab042225 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/nglehuy/warp-transducer/pull/1?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->